### PR TITLE
Fixed permissions issue when setting timezone.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -43,6 +43,7 @@
     
     # Ensure timestamps are in my local timezone
     - name: set timezone
+      become: true
       community.general.timezone:
         name: America/New_York
         


### PR DESCRIPTION
This kept failing unless I used _become_. AFAIK, timedatectl requires sudo to change the timezone so this is possibly correct?